### PR TITLE
Fix data corruption due to short write issue

### DIFF
--- a/CoreWebSocket/WebSocketTypes.h
+++ b/CoreWebSocket/WebSocketTypes.h
@@ -81,6 +81,7 @@ struct WebSocketClient {
     CFWriteStreamRef write;
     
     CFMutableArrayRef writeQueue;
+	CFIndex writeOffset;
     
     CFHTTPMessageRef handShakeRequestHTTPMessage;
     WebSocketProtocol protocol;


### PR DESCRIPTION
This fixes a problem when the data to be sent exceeds the immediate buffer space available. The previous code would write whatever would fit into the buffer and drop the rest. This change ensures the full amount of data always gets sent.